### PR TITLE
Optimize count query and fix sort order for study search

### DIFF
--- a/modules/api/src/main/smithy/search.smithy
+++ b/modules/api/src/main/smithy/search.smithy
@@ -49,7 +49,7 @@ operation Count {
 
   output := {
     @required
-    count: Integer
+    count: Long
   }
 
   errors: [InternalServerError]

--- a/modules/app/src/test/scala/IntegrationSuite.scala
+++ b/modules/app/src/test/scala/IntegrationSuite.scala
@@ -102,8 +102,8 @@ object IntegrationSuite extends IOSuite:
                   name = "study name",
                   owner = "study owner",
                   members = List("member1", "member2"),
-                  chapterNames = "chapter names",
-                  chapterTexts = "chapter texts",
+                  chapterNames = "names",
+                  chapterTexts = "texts",
                   likes = 100,
                   public = true,
                   topics = List("topic1", "topic2")
@@ -111,10 +111,10 @@ object IntegrationSuite extends IOSuite:
               )
             )
           _ <- service.refresh(Index.Study)
-          x <- service.search(Query.study("study name"), 0, 12)
-          y <- service.search(Query.study("study description"), 0, 12)
-          z <- service.search(Query.study("topic1"), 0, 12)
-        yield expect(x.hitIds.size == 1 && x == y && z == x)
+          a <- service.search(Query.study("name"), 0, 12)
+          b <- service.search(Query.study("study description"), 0, 12)
+          c <- service.search(Query.study("topic1"), 0, 12)
+        yield expect(a.hitIds.size == 1 && b == a && c == a)
 
   test("game"): _ =>
     Clients

--- a/modules/core/src/main/scala/Queryable.scala
+++ b/modules/core/src/main/scala/Queryable.scala
@@ -1,12 +1,13 @@
 package lila.search
 
+import com.sksamuel.elastic4s.requests.count.CountRequest
 import com.sksamuel.elastic4s.requests.searches.SearchRequest
 
 trait Queryable[A]:
 
   def searchDef(query: A)(from: From, size: Size): SearchRequest
 
-  def countDef(query: A): SearchRequest
+  def countDef(query: A): CountRequest
 
 case class ParsedQuery(terms: List[String], filters: Map[String, String]):
 

--- a/modules/core/src/main/scala/forum.scala
+++ b/modules/core/src/main/scala/forum.scala
@@ -38,7 +38,7 @@ object ForumQuery:
         .start(from.value)
         .size(size.value)
 
-    def countDef(query: Forum) = search(index).query(makeQuery(query)).size(0)
+    def countDef(query: Forum) = count(index).query(makeQuery(query))
 
     private def makeQuery(query: Forum) =
       val parsed = QueryParser(query.text, List("user"))

--- a/modules/core/src/main/scala/game.scala
+++ b/modules/core/src/main/scala/game.scala
@@ -92,7 +92,7 @@ object GameQuery:
         .size(size.value)
         .timeout(timeout)
 
-    def countDef(query: Game) = search(index).query(makeQuery(query)).size(0).timeout(timeout)
+    def countDef(query: Game) = count(index).query(makeQuery(query))
 
     private def makeQuery(query: Game): Query =
 

--- a/modules/core/src/main/scala/model.scala
+++ b/modules/core/src/main/scala/model.scala
@@ -15,9 +15,9 @@ object SearchResponse:
   def apply(res: ESR): SearchResponse =
     SearchResponse(res.hits.hits.toList.map(_.id))
 
-case class CountResponse(count: Int)
+case class CountResponse(count: Long)
 
 object CountResponse:
 
-  def apply(res: ESR): CountResponse =
-    CountResponse(res.totalHits.toInt)
+  def apply(res: com.sksamuel.elastic4s.requests.count.CountResponse): CountResponse =
+    CountResponse(res.count)

--- a/modules/core/src/main/scala/study.scala
+++ b/modules/core/src/main/scala/study.scala
@@ -59,7 +59,7 @@ object StudyQuery:
           multiMatchQuery(
             parsed.terms.mkString(" ")
           ).fields(searchableFields*).analyzer("english").matchType("most_fields")
-      boolQuery().filter {
+      boolQuery().must {
         matcher :: List(
           parsed("owner").map(termQuery(Fields.owner, _)),
           parsed("member").map(member =>

--- a/modules/core/src/main/scala/study.scala
+++ b/modules/core/src/main/scala/study.scala
@@ -49,7 +49,7 @@ object StudyQuery:
         .start(from.value)
         .size(size.value)
 
-    def countDef(query: Study) = search(index).query(makeQuery(query)).size(0)
+    def countDef(query: Study) = count(index).query(makeQuery(query))
 
     private def makeQuery(query: Study) = {
       val parsed = QueryParser(query.text, List("owner", "member"))

--- a/modules/core/src/main/scala/team.scala
+++ b/modules/core/src/main/scala/team.scala
@@ -33,7 +33,7 @@ object TeamQuery:
         .start(from.value)
         .size(size.value)
 
-    def countDef(query: Team) = search(index).query(makeQuery(query)).size(0)
+    def countDef(query: Team) = count(index).query(makeQuery(query))
 
     private def makeQuery(team: Team) =
       QueryParser(team.text, Nil).terms.map(term => multiMatchQuery(term).fields(searchableFields*)).compile


### PR DESCRIPTION
Fixed:
- [x] count: https://lichess.org/forum/lichess-feedback/when-i-search-games-if-there-are-more-than-10000-it-says-10000-games
- [x] wrong study search: https://lichess.org/forum/lichess-feedback/issue-with-study-search-functionality