### PR TITLE
Game ingestor

### DIFF
--- a/modules/ingestor/src/main/scala/cli.scala
+++ b/modules/ingestor/src/main/scala/cli.scala
@@ -37,16 +37,19 @@ object cli
         res.store,
         config.ingestor.study
       ).toResource
-    yield Executor(forum, study)
+      game <- GameIngestor(res.lichess, res.elastic, res.store, config.ingestor.game).toResource
+    yield Executor(forum, study, game)
 
-  class Executor(val forum: ForumIngestor, val study: StudyIngestor):
+  class Executor(val forum: ForumIngestor, val study: StudyIngestor, val game: GameIngestor):
     def execute(opts: IndexOpts): IO[Unit] =
       opts.index match
         case Index.Forum =>
           forum.run(opts.since, opts.until, opts.dry).compile.drain
         case Index.Study =>
           study.run(opts.since, opts.until, opts.dry).compile.drain
-        case _ => IO.println("We only support forum/study backfill for now")
+        case Index.Game =>
+          game.run(opts.since, opts.until, opts.dry).compile.drain
+        case _ => IO.println("We only support forum/study/game backfill for now")
 
 object opts:
   case class IndexOpts(index: Index, since: Instant, until: Instant, dry: Boolean)

--- a/modules/ingestor/src/main/scala/ingestor.game.scala
+++ b/modules/ingestor/src/main/scala/ingestor.game.scala
@@ -1,0 +1,189 @@
+package lila.search
+package ingestor
+
+import cats.effect.*
+import cats.syntax.all.*
+import com.mongodb.client.model.changestream.FullDocument
+import com.monovore.decline.*
+import io.circe.*
+import mongo4cats.circe.*
+import mongo4cats.collection.MongoCollection
+import mongo4cats.operations.{ Aggregate, Filter }
+import org.bson.BsonTimestamp
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.syntax.*
+
+import java.time.Instant
+import scala.concurrent.duration.*
+
+trait GameIngestor:
+  // watch change events from game5 collection
+  def watch(since: Instant, until: Instant): IO[Unit]
+
+object GameIngestor:
+
+  def apply(games: MongoCollection[IO, DbGame])(using Logger[IO]): GameIngestor = new:
+
+    def watch(since: Instant, until: Instant): IO[Unit] =
+      changes(since, until).compile.drain
+
+    private def changes(
+        since: Instant,
+        until: Instant
+    ): fs2.Stream[IO, List[DbGame]] =
+      val batchSize  = 1000
+      val timeWindow = 10
+      games
+        .watch(aggreate(since, until))
+        .startAtOperationTime(BsonTimestamp(since.getEpochSecond.toInt, 1))
+        .batchSize(batchSize)                     // config.batchSize
+        .fullDocument(FullDocument.UPDATE_LOOKUP) // this is required for update event
+        .boundedStream(batchSize)
+        .groupWithin(batchSize, timeWindow.second) // config.windows
+        .evalTap(_.traverse_(x => info"received $x"))
+        .evalTap(_.filter(_.fullDocument.exists(_.validClock)).traverse_(x => info"count $x"))
+        .map(_.toList.map(_.fullDocument).flatten)
+        .evalTap(_.traverse_(x => info"clock ${x.clock}"))
+        .map(_.filter(_.validClock))
+        .evalTap(_.traverse_(x => info"valid clock ${x.clock}"))
+
+    private def aggreate(since: Instant, until: Instant) =
+      // games have at least 15 moves
+      val turnsFilter    = Filter.gte("fullDocument.t", 30)
+      val standardFilter = Filter.eq("fullDocument.v", 1).or(Filter.notExists("fullDocument.v"))
+      val ratedFilter    = Filter.eq("fullDocument.ra", true)
+      val noAiFilter =
+        Filter
+          .eq("fullDocument.p0.ai", 0)
+          .or(Filter.notExists("fullDocument.p0.ai"))
+          .and(Filter.eq("fullDocument.p1.ai", 0).or(Filter.notExists("fullDocument.p1.ai")))
+
+      // Filter games that finished with Mate, Resign, Stalemate, Draw, Outoftime, Timeout
+      // https://github.com/lichess-org/scalachess/blob/master/core/src/main/scala/Status.scala#L18-L23
+      val statusFilter = Filter.in("fullDocument.s", List(30, 31, 32, 33, 34, 35))
+
+      // filter games that played and ended between since and until
+      val playedTimeFilter =
+        Filter
+          .gte("fullDocument.ca", since)
+          .and(Filter.lte("fullDocument.ua", until))
+
+      val updatedStatusOnlyFilter = Filter
+        .exists("updateDescription.updatedFields.s")
+        .or(Filter.notExists("updateDescription"))
+
+      // required clock config
+      val clockFilter = Filter.exists("fullDocument.c")
+
+      // only human plays
+      val noImportGameFilter = Filter.notExists("fullDocument.pgni")
+
+      val gameFilter = standardFilter
+        .and(turnsFilter)
+        .and(ratedFilter)
+        .and(noAiFilter)
+        .and(statusFilter)
+        .and(updatedStatusOnlyFilter)
+        .and(playedTimeFilter)
+        .and(clockFilter)
+        .and(noImportGameFilter)
+
+      Aggregate.matchBy(gameFilter)
+
+      /*
+       *{
+  _id: 'TaHSAsYD',
+  us: [ 'pedro', 'ikem' ],
+  is: 'AABgAACA',
+  p0: { e: 2264, d: 3 },
+  p1: { e: 2069, d: -3 },
+  s: 35,
+  t: 97,
+  v: 1,
+  ra: true,
+  ca: ISODate('2024-02-29T17:06:28.099Z'),
+  ua: ISODate('2024-02-29T18:06:00.000Z'),
+  so: 5,
+  hp: Binary.createFromBase64('PDVvHX7zZXUV51aObVt//n+PYCv+TKzL6zXvcTbiqlrv551I5GeN/S1rL74i/K9a68ahbTaRzHvo9uTN2+dc', 0),
+  an: false,
+  c: Binary.createFromBase64('CgAA38IA6mQ=', 0),
+  cw: Binary.createFromBase64('wGAhen8MW6C28eG7gbi0S7rEzAvMPLTu1KHlhKUh18BT3zxTY9SgQYDTvHlPCf6QIyB8SJ/PQYihGoTkZtLA', 0),
+  cb: Binary.createFromBase64('vHARnEBZLL6hkblax4GSWiwXenwwssK8dk8LyS4sfqG7D1eo43kerh70+MHF8Bm0ah3leztkZ5KI4yrsrCrO8piEWFA=', 0),
+  w: true,
+  wid: 'pedro'
+}
+       * */
+
+case class DbGame(
+    id: String,                     // _id
+    players: List[String],  // us
+    whitePlayer: DbPlayer,          // p0
+    blackPlayer: DbPlayer,          // p1
+    status: Int,                    // s
+    huffmanPgn: Array[Byte],        // hp
+    encodedClock: Array[Byte],      // c
+    encodedWhiteClock: Array[Byte], // cw
+    encodedBlackClock: Array[Byte], // cb
+    turn: Int,                      // t
+    createdAt: Instant,             // ca
+    moveAt: Instant,                 // ua
+    rated: Boolean,  // ra
+):
+  def clock               = ClockDecoder.read(encodedClock)
+  def validClock: Boolean = clock.exists(_.forall(_.sastify))
+
+val minTotalSeconds = 5 * 60      // 5 minutes
+val maxTotalSeconds = 8 * 60 * 60 // 8 hours
+
+object DbGame:
+
+  given Decoder[DbGame] =
+    Decoder.forProduct12("_id", "us", "p0", "p1", "s", "hp", "c", "cw", "cb", "t", "ca", "ua")(DbGame.apply)
+
+  given Encoder[DbGame] =
+    Encoder.forProduct12("_id", "us", "p0", "p1", "s", "hp", "c", "cw", "cb", "t", "ca", "ua")(g =>
+      (
+        g.id,
+        g.players,
+        g.whitePlayer,
+        g.blackPlayer,
+        g.status,
+        g.huffmanPgn,
+        g.encodedClock,
+        g.encodedWhiteClock,
+        g.encodedBlackClock,
+        g.turn,
+        g.createdAt,
+        g.moveAt
+      )
+    )
+
+case class DbPlayer(rating: Option[Int], ratingDiff: Option[Int], berserk: Option[Boolean]):
+  def isBerserked = berserk.contains(true)
+
+extension (config: chess.Clock.Config)
+
+  // over 60 moves
+  def estimateTotalSecondsOver60Moves = config.limitSeconds.value + 60 * config.incrementSeconds.value
+
+  // Games are equal to or longer than 3+2 / 5+0 or equivalent over 60 moves (e.g., 4+1, 0+30, etc),
+  // but not more than 8h (e.g., no 240+60)
+  def sastify: Boolean =
+    minTotalSeconds <= config.estimateTotalSecondsOver60Moves &&
+      config.estimateTotalSecondsOver60Moves <= maxTotalSeconds
+
+object DbPlayer:
+  given Decoder[DbPlayer] = Decoder.forProduct3("e", "d", "be")(DbPlayer.apply)
+  given Encoder[DbPlayer] = Encoder.forProduct3("e", "d", "be")(p => (p.rating, p.ratingDiff, p.berserk))
+
+object ClockDecoder:
+  import chess.*
+  private def readClockLimit(i: Int) = Clock.LimitSeconds(if i < 181 then i * 60 else (i - 180) * 15)
+
+  private inline def toInt(inline b: Byte): Int = b & 0xff
+
+  def read(ba: Array[Byte]): Option[ByColor[Clock.Config]] =
+    ByColor: color =>
+      ba.take(2).map(toInt) match
+        case Array(b1, b2) => Clock.Config(readClockLimit(b1), Clock.IncrementSeconds(b2)).some
+        case _             => None

--- a/modules/ingestor/src/main/scala/ingestor.game.scala
+++ b/modules/ingestor/src/main/scala/ingestor.game.scala
@@ -4,6 +4,7 @@ package ingestor
 import cats.effect.*
 import cats.syntax.all.*
 import com.mongodb.client.model.changestream.FullDocument
+import com.mongodb.client.model.changestream.OperationType.*
 import io.circe.*
 import mongo4cats.circe.*
 import mongo4cats.collection.MongoCollection
@@ -14,104 +15,72 @@ import org.typelevel.log4cats.syntax.*
 
 import java.time.Instant
 import scala.concurrent.duration.*
+import mongo4cats.operations.Projection
+import mongo4cats.database.MongoDatabase
 
 trait GameIngestor:
-  // watch change events from game5 collection
-  def watch(since: Instant, until: Instant): IO[Unit]
+  // watch change events from game5 collection and ingest games into elastic search
+  def watch: fs2.Stream[IO, Unit]
 
 object GameIngestor:
 
-  def apply(games: MongoCollection[IO, DbGame])(using Logger[IO]): GameIngestor = new:
+  private val index = Index.Game
 
-    def watch(since: Instant, until: Instant): IO[Unit] =
-      changes(since, until).compile.drain
+  private val interestedOperations = List(INSERT, REPLACE).map(_.getValue) // We don't delete games
 
-    private def changes(
-        since: Instant,
-        until: Instant
-    ): fs2.Stream[IO, List[DbGame]] =
-      val batchSize  = 1000
-      val timeWindow = 10
-      games
-        .watch(aggreate(since, until))
-        .startAtOperationTime(BsonTimestamp(since.getEpochSecond.toInt, 1))
-        .batchSize(batchSize)                     // config.batchSize
+  // private val interestedFields = List(_id, F.text, F.topicId, F.troll, F.createdAt, F.userId, F.erasedAt)
+  // private val postProjection   = Projection.include(interestedFields)
+
+  private val interestedEventFields =
+    List(
+      "operationType",
+      "clusterTime",
+      "documentKey._id",
+      "fullDocument"
+    ) // TODO only include interestedFields
+  private val eventProjection = Projection.include(interestedEventFields)
+
+  private val aggregate =
+    Aggregate.project(eventProjection)
+
+  def apply(mongo: MongoDatabase[IO], elastic: ESClient[IO], store: KVStore, config: IngestorConfig.Game)(
+      using Logger[IO]
+  ): IO[GameIngestor] =
+    (mongo.getCollectionWithCodec[DbGame]("game5")).map(apply(elastic, store, config))
+
+  def apply(
+      elastic: ESClient[IO],
+      store: KVStore,
+      config: IngestorConfig.Game
+  )(games: MongoCollection[IO, DbGame])(using Logger[IO]): GameIngestor = new:
+
+    def watch: fs2.Stream[IO, Unit] =
+      fs2.Stream
+        .eval(startAt.flatTap(since => info"Starting forum ingestor from $since"))
+        .flatMap: since =>
+          changes(since)
+            .evalMap(IO.println)
+
+    private def changes(since: Option[Instant]): fs2.Stream[IO, List[DbGame]] =
+      val builder = games.watch(aggregate)
+      // skip the first event if we're starting from a specific timestamp
+      // since the event at that timestamp is already indexed
+      val skip = since.fold(0)(_ => 1)
+      since
+        .fold(builder)(x => builder.startAtOperationTime(x.asBsonTimestamp))
         .fullDocument(FullDocument.UPDATE_LOOKUP) // this is required for update event
-        .boundedStream(batchSize)
-        .groupWithin(batchSize, timeWindow.second) // config.windows
+        .batchSize(config.batchSize)              // config.batchSize
+        .boundedStream(config.batchSize)
+        .drop(skip)
+        .groupWithin(config.batchSize, config.timeWindows.second) // config.windows
         .evalTap(_.traverse_(x => info"received $x"))
-        .evalTap(_.filter(_.fullDocument.exists(_.validClock)).traverse_(x => info"count $x"))
         .map(_.toList.map(_.fullDocument).flatten)
         .evalTap(_.traverse_(x => info"clock ${x.clock}"))
         .map(_.filter(_.validClock))
         .evalTap(_.traverse_(x => info"valid clock ${x.clock}"))
 
-    private def aggreate(since: Instant, until: Instant) =
-      // games have at least 15 moves
-      val turnsFilter    = Filter.gte("fullDocument.t", 30)
-      val standardFilter = Filter.eq("fullDocument.v", 1).or(Filter.notExists("fullDocument.v"))
-      val ratedFilter    = Filter.eq("fullDocument.ra", true)
-      val noAiFilter =
-        Filter
-          .eq("fullDocument.p0.ai", 0)
-          .or(Filter.notExists("fullDocument.p0.ai"))
-          .and(Filter.eq("fullDocument.p1.ai", 0).or(Filter.notExists("fullDocument.p1.ai")))
-
-      // Filter games that finished with Mate, Resign, Stalemate, Draw, Outoftime, Timeout
-      // https://github.com/lichess-org/scalachess/blob/master/core/src/main/scala/Status.scala#L18-L23
-      val statusFilter = Filter.in("fullDocument.s", List(30, 31, 32, 33, 34, 35))
-
-      // filter games that played and ended between since and until
-      val playedTimeFilter =
-        Filter
-          .gte("fullDocument.ca", since)
-          .and(Filter.lte("fullDocument.ua", until))
-
-      val updatedStatusOnlyFilter = Filter
-        .exists("updateDescription.updatedFields.s")
-        .or(Filter.notExists("updateDescription"))
-
-      // required clock config
-      val clockFilter = Filter.exists("fullDocument.c")
-
-      // only human plays
-      val noImportGameFilter = Filter.notExists("fullDocument.pgni")
-
-      val gameFilter = standardFilter
-        .and(turnsFilter)
-        .and(ratedFilter)
-        .and(noAiFilter)
-        .and(statusFilter)
-        .and(updatedStatusOnlyFilter)
-        .and(playedTimeFilter)
-        .and(clockFilter)
-        .and(noImportGameFilter)
-
-      Aggregate.matchBy(gameFilter)
-
-      /*
-       *{
-  _id: 'TaHSAsYD',
-  us: [ 'pedro', 'ikem' ],
-  is: 'AABgAACA',
-  p0: { e: 2264, d: 3 },
-  p1: { e: 2069, d: -3 },
-  s: 35,
-  t: 97,
-  v: 1,
-  ra: true,
-  ca: ISODate('2024-02-29T17:06:28.099Z'),
-  ua: ISODate('2024-02-29T18:06:00.000Z'),
-  so: 5,
-  hp: Binary.createFromBase64('PDVvHX7zZXUV51aObVt//n+PYCv+TKzL6zXvcTbiqlrv551I5GeN/S1rL74i/K9a68ahbTaRzHvo9uTN2+dc', 0),
-  an: false,
-  c: Binary.createFromBase64('CgAA38IA6mQ=', 0),
-  cw: Binary.createFromBase64('wGAhen8MW6C28eG7gbi0S7rEzAvMPLTu1KHlhKUh18BT3zxTY9SgQYDTvHlPCf6QIyB8SJ/PQYihGoTkZtLA', 0),
-  cb: Binary.createFromBase64('vHARnEBZLL6hkblax4GSWiwXenwwssK8dk8LyS4sfqG7D1eo43kerh70+MHF8Bm0ah3leztkZ5KI4yrsrCrO8piEWFA=', 0),
-  w: true,
-  wid: 'pedro'
-}
-       * */
+    private def startAt: IO[Option[Instant]] =
+      config.startAt.fold(store.get(index.value))(Instant.ofEpochSecond(_).some.pure[IO])
 
 final case class GameSource(
     status: Int,

--- a/modules/ingestor/src/main/scala/ingestor.game.scala
+++ b/modules/ingestor/src/main/scala/ingestor.game.scala
@@ -3,23 +3,23 @@ package ingestor
 
 import cats.effect.*
 import cats.syntax.all.*
+import chess.Speed
+import chess.variant.*
 import com.mongodb.client.model.changestream.FullDocument
 import com.mongodb.client.model.changestream.OperationType.*
 import io.circe.*
+import lila.search.spec.GameSource
 import mongo4cats.circe.*
 import mongo4cats.collection.MongoCollection
-import mongo4cats.operations.{ Aggregate, Filter }
+import mongo4cats.database.MongoDatabase
+import mongo4cats.models.collection.ChangeStreamDocument
+import mongo4cats.operations.{ Aggregate, Filter, Projection }
 import org.bson.BsonTimestamp
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.syntax.*
 
 import java.time.Instant
 import scala.concurrent.duration.*
-import mongo4cats.operations.Projection
-import mongo4cats.database.MongoDatabase
-import lila.search.spec.GameSource
-import chess.variant.*
-import chess.Speed
 
 trait GameIngestor:
   // watch change events from game5 collection and ingest games into elastic search
@@ -29,10 +29,8 @@ object GameIngestor:
 
   private val index = Index.Game
 
-  private val interestedOperations = List(INSERT, REPLACE, DELETE).map(_.getValue)
-
-  // private val interestedFields = List(_id, F.text, F.topicId, F.troll, F.createdAt, F.userId, F.erasedAt)
-  // private val postProjection   = Projection.include(interestedFields)
+  private val interestedOperations = List(UPDATE, DELETE).map(_.getValue)
+  private val eventFilter          = Filter.in("operationType", interestedOperations)
 
   private val interestedEventFields =
     List(
@@ -41,15 +39,24 @@ object GameIngestor:
       "documentKey._id",
       "fullDocument"
     ) // TODO only include interestedFields
+
   private val eventProjection = Projection.include(interestedEventFields)
 
+  // Filter games that finished
+  // https://github.com/lichess-org/scalachess/blob/master/core/src/main/scala/Status.scala#L18-L27
+  val statusFilter   = Filter.gte("fullDocument.s", 30)
+  val noImportFilter = Filter.ne("fullDocument.so", 7)
+
+  // https://github.com/lichess-org/lila/blob/65e6dd88e99cfa0068bc790a4518a6edb3513f54/modules/gameSearch/src/main/GameSearchApi.scala#L52
+  val gameFilter = statusFilter.and(noImportFilter)
+
   private val aggregate =
-    Aggregate.project(eventProjection)
+    Aggregate.matchBy(eventFilter.and(gameFilter)).combinedWith(Aggregate.project(eventProjection))
 
   def apply(mongo: MongoDatabase[IO], elastic: ESClient[IO], store: KVStore, config: IngestorConfig.Game)(
       using Logger[IO]
   ): IO[GameIngestor] =
-    (mongo.getCollectionWithCodec[DbGame]("game5")).map(apply(elastic, store, config))
+    mongo.getCollectionWithCodec[DbGame]("game5").map(apply(elastic, store, config))
 
   def apply(
       elastic: ESClient[IO],
@@ -59,12 +66,27 @@ object GameIngestor:
 
     def watch: fs2.Stream[IO, Unit] =
       fs2.Stream
-        .eval(startAt.flatTap(since => info"Starting forum ingestor from $since"))
+        .eval(startAt.flatTap(since => info"Starting game ingestor from $since"))
         .flatMap: since =>
-          changes(since).void
-    // .evalMap(IO.println)
+          changes(since)
+            .evalMap: events =>
+              val lastEventTimestamp  = events.lastOption.flatMap(_.clusterTime).flatMap(_.asInstant)
+              val (toDelete, toIndex) = events.partition(_.operationType == DELETE)
+              storeBulk(toIndex.flatten(_.fullDocument))
+                *> elastic.deleteMany(index, toDelete)
+                *> saveLastIndexedTimestamp(lastEventTimestamp.getOrElse(Instant.now))
 
-    private def changes(since: Option[Instant]): fs2.Stream[IO, List[DbGame]] =
+    private def storeBulk(docs: List[DbGame]): IO[Unit] =
+      val sources = docs.map(_.toSource)
+      info"Received ${docs.size} ${index.value}s to index" *>
+        elastic
+          .storeBulk(index, sources)
+          .handleErrorWith: e =>
+            Logger[IO].error(e)(s"Failed to index ${index.value}s: ${docs.map(_.id).mkString(", ")}")
+          .whenA(sources.nonEmpty)
+        *> info"Indexed ${sources.size} ${index.value}s"
+
+    private def changes(since: Option[Instant]): fs2.Stream[IO, List[ChangeStreamDocument[DbGame]]] =
       val builder = games.watch(aggregate)
       // skip the first event if we're starting from a specific timestamp
       // since the event at that timestamp is already indexed
@@ -75,25 +97,28 @@ object GameIngestor:
         .boundedStream(config.batchSize)
         // .evalTap(x => info"received $x")
         .groupWithin(config.batchSize, config.timeWindows.second) // config.windows
-        // .evalTap(_.traverse_(x => info"received $x"))
-        .map(_.toList.map(_.fullDocument).flatten)
-        .evalTap(_.traverse_(x => IO.println(x.debug)))
+        .map(_.toList.unique)
+      // .map(_.map(_.fullDocument).flatten)
+      // .evalTap(_.traverse_(x => IO.println(x.debug)))
+
+    private def saveLastIndexedTimestamp(time: Instant): IO[Unit] =
+      store.put(index.value, time)
+        *> info"Stored last indexed time ${time.getEpochSecond} for $index"
 
     private def startAt: IO[Option[Instant]] =
       config.startAt.fold(store.get(index.value))(Instant.ofEpochSecond(_).some.pure[IO])
 
 type PlayerId = String
 case class DbGame(
-    id: String,                 // _id
-    players: List[PlayerId],    // us
-    winnerId: Option[PlayerId], // wid
-    createdAt: Instant,         // ca
-    movedAt: Instant,           // ua
-    ply: Int,                   // t
-    analysed: Option[Boolean],  // an
-    whitePlayer: DbPlayer,      // p0
-    blackPlayer: DbPlayer,      // p1
-    // id = GamePlayerId(color.fold(ids.take(4), ids.drop(4))),
+    id: String,                             // _id
+    players: Option[List[PlayerId]],        // us
+    winnerId: Option[PlayerId],             // wid
+    createdAt: Instant,                     // ca
+    movedAt: Instant,                       // ua
+    ply: Int,                               // t
+    analysed: Option[Boolean],              // an
+    whitePlayer: DbPlayer,                  // p0
+    blackPlayer: DbPlayer,                  // p1
     playerIds: String,                      // is
     binaryPieces: Option[Array[Byte]],      // ps // ByteVector from scodec
     huffmanPgn: Option[Array[Byte]],        // hp
@@ -102,23 +127,22 @@ case class DbGame(
     moveTimes: Option[Array[Byte]],         // mt
     encodedWhiteClock: Option[Array[Byte]], // cw
     encodedBlackClock: Option[Array[Byte]], // cb
-    // default to be false
-    rated: Option[Boolean],      // ra
-    variant: Option[Int],        // v
-    source: Option[Int],         // so
-    winnerColor: Option[Boolean] // w
+    rated: Option[Boolean],                 // ra
+    variant: Option[Int],                   // v
+    source: Option[Int],                    // so
+    winnerColor: Option[Boolean]            // w
 ):
   def clockConfig      = encodedClock.flatMap(ClockDecoder.read).map(_.white)
   def clockInit        = clockConfig.map(_.limitSeconds.value)
   def clockInc         = clockConfig.map(_.incrementSeconds.value)
-  def whiteId          = players.headOption
-  def blackId          = players.lift(1)
+  def whiteId          = players.flatMap(_.headOption)
+  def blackId          = players.flatMap(_.lift(1))
   def variantOrDefault = Variant.idOrDefault(variant.map(Variant.Id.apply))
   def speed            = Speed(clockConfig)
 
-  private[ingestor] def loser = players.find(_.some != winnerId)
+  def loser = players.flatMap(_.find(_.some != winnerId))
 
-  private def aiLevel = whitePlayer.aiLevel.orElse(blackPlayer.aiLevel)
+  def aiLevel = whitePlayer.aiLevel.orElse(blackPlayer.aiLevel)
 
   // https://github.com/lichess-org/lila/blob/65e6dd88e99cfa0068bc790a4518a6edb3513f54/modules/core/src/main/game/Game.scala#L261
   private def averageUsersRating = List(whitePlayer.rating, blackPlayer.rating).flatten match
@@ -131,32 +155,33 @@ case class DbGame(
     val seconds = (movedAt.toEpochMilli / 1000 - createdAt.toEpochMilli / 1000)
     Option.when(seconds < 60 * 60 * 12)(seconds.toInt)
 
-  def toSource: GameSource =
-    GameSource(
-      status = status,
-      turns = (ply + 1) / 2,
-      rated = rated.getOrElse(false),
-      perf = DbGame.perfId(variantOrDefault, speed),
-      winnerColor = winnerColor.fold(3)(if _ then 1 else 2),
-      date = SearchDateTime.fromInstant(movedAt),
-      analysed = analysed.getOrElse(false),
-      uids = players.some,
-      winner = winnerId,
-      loser = loser,
-      averageRating = averageUsersRating,
-      ai = aiLevel,
-      duration = durationSeconds,
-      clockInit = clockInit,
-      clockInc = clockInc,
-      whiteUser = whiteId,
-      blackUser = blackId,
-      source = source
-    )
+  def toSource =
+    id ->
+      GameSource(
+        status = status,
+        turns = (ply + 1) / 2,
+        rated = rated.getOrElse(false),
+        perf = DbGame.perfId(variantOrDefault, speed),
+        winnerColor = winnerColor.fold(3)(if _ then 1 else 2),
+        date = SearchDateTime.fromInstant(movedAt),
+        analysed = analysed.getOrElse(false),
+        uids = players.map(_.filter(_.nonEmpty)),
+        winner = winnerId,
+        loser = loser,
+        averageRating = averageUsersRating,
+        ai = aiLevel,
+        duration = durationSeconds,
+        clockInit = clockInit,
+        clockInc = clockInc,
+        whiteUser = whiteId,
+        blackUser = blackId,
+        source = source
+      )
 
-  def debug: String =
+  def debug =
     import smithy4s.json.Json.given
     import com.github.plokhotnyuk.jsoniter_scala.core.*
-    writeToString(toSource)
+    id -> writeToString(toSource._2)
 
 object DbGame:
 

--- a/modules/ingestor/src/main/scala/ingestor.scala
+++ b/modules/ingestor/src/main/scala/ingestor.scala
@@ -11,7 +11,7 @@ trait Ingestor:
 
 object Ingestor:
 
-  def apply1(
+  def apply(
       lichess: MongoDatabase[IO],
       study: MongoDatabase[IO],
       local: MongoDatabase[IO],
@@ -22,19 +22,18 @@ object Ingestor:
     (
       ForumIngestor(lichess, elastic, store, config.forum),
       TeamIngestor(lichess, elastic, store, config.team),
-      StudyIngestor(study, local, elastic, store, config.study),
-      GameIngestor(lichess, elastic, store, config.game)
-    ).mapN: (forum, team, study, game) =>
+      StudyIngestor(study, local, elastic, store, config.study)
+    ).mapN: (forum, team, study) =>
       new Ingestor:
         def run() =
           fs2
-            .Stream(forum.watch, team.watch, study.watch, game.watch)
+            .Stream(forum.watch, team.watch, study.watch)
             .covary[IO]
             .parJoinUnbounded
             .compile
             .drain
 
-  def apply(
+  def apply_(
       lichess: MongoDatabase[IO],
       study: MongoDatabase[IO],
       local: MongoDatabase[IO],

--- a/modules/ingestor/src/main/scala/ingestor.scala
+++ b/modules/ingestor/src/main/scala/ingestor.scala
@@ -11,7 +11,7 @@ trait Ingestor:
 
 object Ingestor:
 
-  def apply(
+  def apply1(
       lichess: MongoDatabase[IO],
       study: MongoDatabase[IO],
       local: MongoDatabase[IO],
@@ -22,13 +22,28 @@ object Ingestor:
     (
       ForumIngestor(lichess, elastic, store, config.forum),
       TeamIngestor(lichess, elastic, store, config.team),
-      StudyIngestor(study, local, elastic, store, config.study)
-    ).mapN: (forum, team, study) =>
+      StudyIngestor(study, local, elastic, store, config.study),
+      GameIngestor(lichess, elastic, store, config.game)
+    ).mapN: (forum, team, study, game) =>
       new Ingestor:
         def run() =
           fs2
-            .Stream(forum.watch, team.watch, study.watch)
+            .Stream(forum.watch, team.watch, study.watch, game.watch)
             .covary[IO]
             .parJoinUnbounded
             .compile
             .drain
+
+  def apply(
+      lichess: MongoDatabase[IO],
+      study: MongoDatabase[IO],
+      local: MongoDatabase[IO],
+      elastic: ESClient[IO],
+      store: KVStore,
+      config: IngestorConfig
+  )(using Logger[IO]): IO[Ingestor] =
+    GameIngestor(lichess, elastic, store, config.game)
+      .map: game =>
+        new Ingestor:
+          def run() =
+            game.watch.compile.drain

--- a/modules/ingestor/src/main/scala/package.scala
+++ b/modules/ingestor/src/main/scala/package.scala
@@ -74,7 +74,7 @@ extension (elastic: ESClient[IO])
       deleteMany_(index, events.flatMap(_.id).map(Id.apply)).whenA(events.nonEmpty)
 
   @scala.annotation.targetName("deleteManyWithChanges")
-  def deleteMany(index: Index, events: List[ChangeStreamDocument[Document]])(using Logger[IO]): IO[Unit] =
+  def deleteMany[A](index: Index, events: List[ChangeStreamDocument[A]])(using Logger[IO]): IO[Unit] =
     info"Received ${events.size} ${index.value} to delete" *>
       deleteMany_(index, events.flatMap(_.docId).map(Id.apply)).whenA(events.nonEmpty)
 


### PR DESCRIPTION
Implement game ingestor, but doesn't let it runs yet.

This also adds `index` and `watch` command for `game`.
`watch` is similar to a normal ingestor watch functionality but it runs via cli and has `dryRun` option.

My plan is to merge/deploy this and test the functionality with `watch --index game --dryRun` to see if it actually works and find the best config for game ingestor.
