### PR TITLE
Fix oom by using streaming operator

### DIFF
--- a/modules/ingestor/src/main/scala/mongo.chapter.scala
+++ b/modules/ingestor/src/main/scala/mongo.chapter.scala
@@ -110,6 +110,9 @@ object ChapterRepo:
     def byStudyIds(ids: List[String]): IO[Map[String, StudyData]] =
       coll
         .aggregateWithCodec[StudyData](Query.aggregate(ids))
-        .all
         // .flatTap(docs => Logger[IO].debug(s"Received $docs chapters"))
+        .stream
+        .compile
+        .toList
+        .flatTap(docs => Logger[IO].debug(s"Received $docs chapters"))
         .map(_.map(x => x._id -> x).toMap)


### PR DESCRIPTION
This reverts commit cd4a64850ac9865a09d9acc17ee6cfda43b2b386.

Fix

```
Dec 03 22:56:09 sirch app[3984155]: com.mongodb.MongoInternalException: Unexpected exception
Dec 03 22:56:09 sirch app[3984155]:         at com.mongodb.internal.connection.InternalStreamConnection.translateReadException(InternalStreamConnection.java:818)
Dec 03 22:56:09 sirch app[3984155]:         at com.mongodb.internal.connection.InternalStreamConnection.access$300(InternalStreamConnection.java:103)
Dec 03 22:56:09 sirch app[3984155]:         at com.mongodb.internal.connection.InternalStreamConnection$2.failed(InternalStreamConnection.java:749)
Dec 03 22:56:09 sirch app[3984155]:         at com.mongodb.internal.connection.AsynchronousChannelStream$BasicCompletionHandler.failed(AsynchronousChannelStream.java:255)
Dec 03 22:56:09 sirch app[3984155]:         at com.mongodb.internal.connection.AsynchronousChannelStream$BasicCompletionHandler.failed(AsynchronousChannelStream.java:220)
Dec 03 22:56:09 sirch app[3984155]:         at java.base/sun.nio.ch.Invoker.invokeUnchecked(Invoker.java:131)
Dec 03 22:56:09 sirch app[3984155]:         at java.base/sun.nio.ch.Invoker.invokeDirect(Invoker.java:160)
Dec 03 22:56:09 sirch app[3984155]:         at java.base/sun.nio.ch.UnixAsynchronousSocketChannelImpl.implRead(UnixAsynchronousSocketChannelImpl.java:573)
Dec 03 22:56:09 sirch app[3984155]:         at java.base/sun.nio.ch.AsynchronousSocketChannelImpl.read(AsynchronousSocketChannelImpl.java:277)
Dec 03 22:56:09 sirch app[3984155]:         at java.base/sun.nio.ch.AsynchronousSocketChannelImpl.read(AsynchronousSocketChannelImpl.java:298)
Dec 03 22:56:09 sirch app[3984155]:         at com.mongodb.internal.connection.AsynchronousSocketChannelStream$AsynchronousSocketChannelAdapter.read(AsynchronousSocketChannelStream.java:144)
Dec 03 22:56:09 sirch app[3984155]:         at com.mongodb.internal.connection.AsynchronousChannelStream.readAsync(AsynchronousChannelStream.java:116)
Dec 03 22:56:09 sirch app[3984155]:         at com.mongodb.internal.connection.InternalStreamConnection.readAsync(InternalStreamConnection.java:740)
Dec 03 22:56:09 sirch app[3984155]:         at com.mongodb.internal.connection.InternalStreamConnection.access$500(InternalStreamConnection.java:103)
Dec 03 22:56:09 sirch app[3984155]:         at com.mongodb.internal.connection.InternalStreamConnection$MessageHeaderCallback.onResult(InternalStreamConnection.java:898)
Dec 03 22:56:09 sirch app[3984155]:         at com.mongodb.internal.connection.InternalStreamConnection$MessageHeaderCallback.onResult(InternalStreamConnection.java:880)
Dec 03 22:56:09 sirch app[3984155]:         at com.mongodb.internal.connection.InternalStreamConnection$2.completed(InternalStreamConnection.java:743)
Dec 03 22:56:09 sirch app[3984155]:         at com.mongodb.internal.connection.InternalStreamConnection$2.completed(InternalStreamConnection.java:740)
Dec 03 22:56:09 sirch app[3984155]:         at com.mongodb.internal.connection.AsynchronousChannelStream$BasicCompletionHandler.completed(AsynchronousChannelStream.java:240)
Dec 03 22:56:09 sirch app[3984155]:         at com.mongodb.internal.connection.AsynchronousChannelStream$BasicCompletionHandler.completed(AsynchronousChannelStream.java:220)
Dec 03 22:56:09 sirch app[3984155]:         at java.base/sun.nio.ch.Invoker.invokeUnchecked(Invoker.java:129)
Dec 03 22:56:09 sirch app[3984155]:         at java.base/sun.nio.ch.Invoker$2.run(Invoker.java:221)
Dec 03 22:56:09 sirch app[3984155]:         at java.base/sun.nio.ch.AsynchronousChannelGroupImpl$1.run(AsynchronousChannelGroupImpl.java:113)
Dec 03 22:56:09 sirch app[3984155]:         at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
Dec 03 22:56:09 sirch app[3984155]:         at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
Dec 03 22:56:09 sirch app[3984155]:         at java.base/java.lang.Thread.run(Thread.java:1583)
Dec 03 22:56:09 sirch app[3984155]:         at async_ @ mongo4cats.syntax$PublisherSyntax$.asyncIterable$extension(syntax.scala:62)
Dec 03 22:56:09 sirch app[3984155]:         at map @ lila.search.ingestor.ChapterRepo$$anon$5.byStudyIds(mongo.chapter.scala:115)
Dec 03 22:56:09 sirch app[3984155]:         at flatMap @ lila.search.ingestor.StudyRepo$$anon$1.toSources(mongo.study.scala:93)
Dec 03 22:56:09 sirch app[3984155]: Caused by: java.lang.OutOfMemoryError: Cannot reserve 1405902 bytes of direct buffer memory (allocated: 2146204351, limit: 2147483648)
Dec 03 22:56:09 sirch app[3984155]:         at java.base/java.nio.Bits.reserveMemory(Bits.java:178)
Dec 03 22:56:09 sirch app[3984155]:         at java.base/java.nio.DirectByteBuffer.<init>(DirectByteBuffer.java:111)
Dec 03 22:56:09 sirch app[3984155]:         at java.base/java.nio.ByteBuffer.allocateDirect(ByteBuffer.java:360)
Dec 03 22:56:09 sirch app[3984155]:         at java.base/sun.nio.ch.Util.getTemporaryDirectBuffer(Util.java:242)
Dec 03 22:56:09 sirch app[3984155]:         at java.base/sun.nio.ch.IOUtil.read(IOUtil.java:303)
Dec 03 22:56:09 sirch app[3984155]:         at java.base/sun.nio.ch.IOUtil.read(IOUtil.java:276)
Dec 03 22:56:09 sirch app[3984155]:         at java.base/sun.nio.ch.UnixAsynchronousSocketChannelImpl.implRead(UnixAsynchronousSocketChannelImpl.java:525)
Dec 03 22:56:09 sirch app[3984155]:         at java.base/sun.nio.ch.AsynchronousSocketChannelImpl.read(AsynchronousSocketChannelImpl.java:277)
Dec 03 22:56:09 sirch app[3984155]:         at java.base/sun.nio.ch.AsynchronousSocketChannelImpl.read(AsynchronousSocketChannelImpl.java:298)
Dec 03 22:56:09 sirch app[3984155]:         at com.mongodb.internal.connection.AsynchronousSocketChannelStream$AsynchronousSocketChannelAdapter.read(AsynchronousSocketChannelStream.java:144)
Dec 03 22:56:09 sirch app[3984155]:         at com.mongodb.internal.connection.AsynchronousChannelStream.readAsync(AsynchronousChannelStream.java:116)
Dec 03 22:56:09 sirch app[3984155]:         at com.mongodb.internal.connection.InternalStreamConnection.readAsync(InternalStreamConnection.java:740)
Dec 03 22:56:09 sirch app[3984155]:         at com.mongodb.internal.connection.InternalStreamConnection.access$500(InternalStreamConnection.java:103)
Dec 03 22:56:09 sirch app[3984155]:         at com.mongodb.internal.connection.InternalStreamConnection$MessageHeaderCallback.onResult(InternalStreamConnection.java:898)
Dec 03 22:56:09 sirch app[3984155]:         at com.mongodb.internal.connection.InternalStreamConnection$MessageHeaderCallback.onResult(InternalStreamConnection.java:880)
Dec 03 22:56:09 sirch app[3984155]:         at com.mongodb.internal.connection.InternalStreamConnection$2.completed(InternalStreamConnection.java:743)
Dec 03 22:56:09 sirch app[3984155]:         at com.mongodb.internal.connection.InternalStreamConnection$2.completed(InternalStreamConnection.java:740)
Dec 03 22:56:09 sirch app[3984155]:         at com.mongodb.internal.connection.AsynchronousChannelStream$BasicCompletionHandler.completed(AsynchronousChannelStream.java:240)
Dec 03 22:56:09 sirch app[3984155]:         at com.mongodb.internal.connection.AsynchronousChannelStream$BasicCompletionHandler.completed(AsynchronousChannelStream.java:220)
Dec 03 22:56:09 sirch app[3984155]:         at java.base/sun.nio.ch.Invoker.invokeUnchecked(Invoker.java:129)
Dec 03 22:56:09 sirch app[3984155]:         at java.base/sun.nio.ch.Invoker$2.run(Invoker.java:221)
Dec 03 22:56:09 sirch app[3984155]:         at java.base/sun.nio.ch.AsynchronousChannelGroupImpl$1.run(AsynchronousChannelGroupImpl.java:113)
Dec 03 22:56:09 sirch app[3984155]:         at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
Dec 03 22:56:09 sirch app[3984155]:         at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
Dec 03 22:56:09 sirch app[3984155]:         at java.base/java.lang.Thread.run(Thread.java:1583)
```