### PR TITLE
Use new cats-mtl submarine error propagation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -70,6 +70,7 @@ lazy val elastic = project
     libraryDependencies ++= Seq(
       catsCore,
       catsEffect,
+      catsMtl,
       http4sClient,
       elastic4sHttp4sClient,
       otel4sCore

--- a/modules/app/src/main/scala/service.health.scala
+++ b/modules/app/src/main/scala/service.health.scala
@@ -2,6 +2,7 @@ package lila.search
 package app
 
 import cats.effect.*
+import cats.mtl.Handle.*
 import cats.syntax.all.*
 import lila.search.spec.*
 import org.typelevel.log4cats.{ Logger, LoggerFactory }
@@ -11,12 +12,13 @@ class HealthServiceImpl(esClient: ESClient[IO])(using LoggerFactory[IO]) extends
   given Logger[IO] = LoggerFactory[IO].getLogger
 
   override def healthCheck(): IO[HealthCheckOutput] =
-    esClient.status
-      .flatMap(transform)
-      .map(HealthCheckOutput(_))
-      .handleErrorWith: e =>
-        Logger[IO].error(e)("Error in health check") *>
-          IO.raiseError(InternalServerError(s"Internal server error ${e.getMessage}"))
+    allow:
+      esClient.status
+        .flatMap(transform)
+        .map(HealthCheckOutput(_))
+    .rescue: e =>
+      Logger[IO].error(e.asException)("Error in health check") *>
+        IO.raiseError(InternalServerError(s"Internal server error ${e.reason}"))
 
   private def transform(status: String): IO[ElasticStatus] =
     status match

--- a/modules/e2e/src/test/scala/CompatSuite.scala
+++ b/modules/e2e/src/test/scala/CompatSuite.scala
@@ -67,18 +67,18 @@ object CompatSuite extends weaver.IOSuite:
 
   def fakeClient: ESClient[IO] = new:
 
-    override def store[A](index: Index, id: Id, obj: A)(using Indexable[A]): IO[Unit] = IO.unit
+    override def store[A](index: Index, id: Id, obj: A)(using Indexable[A]) = IO.unit
 
-    override def storeBulk[A](index: Index, objs: Seq[SourceWithId[A]])(using Indexable[A]): IO[Unit] =
+    override def storeBulk[A](index: Index, objs: Seq[SourceWithId[A]])(using Indexable[A]) =
       IO.unit
 
-    override def putMapping(index: Index): IO[Unit] = IO.unit
+    override def putMapping(index: Index) = IO.unit
 
-    override def refreshIndex(index: Index): IO[Unit] = IO.unit
+    override def refreshIndex(index: Index) = IO.unit
 
-    override def deleteOne(index: Index, id: Id): IO[Unit] = IO.unit
+    override def deleteOne(index: Index, id: Id) = IO.unit
 
-    override def deleteMany(index: Index, ids: List[Id]): IO[Unit] = IO.unit
+    override def deleteMany(index: Index, ids: List[Id]) = IO.unit
 
     override def count[A](query: A)(using Queryable[A]) =
       IO.pure(0)
@@ -86,7 +86,7 @@ object CompatSuite extends weaver.IOSuite:
     override def search[A](query: A, from: From, size: Size)(using Queryable[A]) =
       IO.pure(Nil)
 
-    override def status: IO[String] = IO.pure("yellow")
+    override def status = IO.pure("yellow")
 
   given system: ActorSystem = ActorSystem()
 

--- a/modules/e2e/src/test/scala/IntegrationSuite.scala
+++ b/modules/e2e/src/test/scala/IntegrationSuite.scala
@@ -1,9 +1,13 @@
 package lila.search
 package app
 package test
+
+import cats.Functor
 import cats.effect.{ IO, Resource }
+import cats.mtl.Raise
 import cats.syntax.all.*
 import com.comcast.ip4s.*
+import com.sksamuel.elastic4s.ElasticError
 import lila.search.ingestor.Ingestor.given
 import lila.search.spec.*
 import org.http4s.Uri
@@ -22,6 +26,10 @@ object IntegrationSuite extends IOSuite:
   given Logger[IO] = NoOpLogger[IO]
   given LoggerFactory[IO] = NoOpFactory[IO]
   given Meter[IO] = Meter.noop[IO]
+  private given Raise[IO, ElasticError]:
+    def functor: Functor[IO] = Functor[IO]
+    def raise[E <: ElasticError, A](e: E): IO[A] =
+      IO.raiseError(e.asException)
 
   private val uri = Uri.unsafeFromString("http://localhost:9999")
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,10 +5,11 @@ object Dependencies {
 
   val lilaMaven = "lila-maven" at "https://raw.githubusercontent.com/lichess-org/lila-maven/master"
   val jitpack = "jitpack".at("https://jitpack.io")
-  val ourResolvers = Seq(lilaMaven, jitpack)
+  val ourResolvers = Seq(lilaMaven, jitpack, Resolver.sonatypeCentralSnapshots)
 
   object V {
     val catsEffect = "3.6.3"
+    val catsMtl    = "1.6-6ad7882-SNAPSHOT"
     val chess      = "17.9.3"
     val ciris      = "3.9.0"
     val decline    = "2.5.0"
@@ -27,6 +28,7 @@ object Dependencies {
 
   val catsCore   = "org.typelevel" %% "cats-core"   % "2.13.0"
   val catsEffect = "org.typelevel" %% "cats-effect" % V.catsEffect
+  val catsMtl    = "org.typelevel" %% "cats-mtl" % V.catsMtl
 
   val fs2   = "co.fs2" %% "fs2-core" % V.fs2
   val fs2IO = "co.fs2" %% "fs2-io"   % V.fs2


### PR DESCRIPTION
Instead of throw an exception, we raise ElasticError instead and in the callsite we handle them by allow/rescue syntax
