### PR TITLE
Add forum category filtering to lila-search

### DIFF
--- a/modules/api/src/main/smithy/search.smithy
+++ b/modules/api/src/main/smithy/search.smithy
@@ -68,6 +68,8 @@ structure Forum {
   text: String
   @required
   troll: Boolean = false
+  @default
+  categIds: Strings
 }
 
 structure Ublog {

--- a/modules/e2e/src/test/scala/IntegrationSuite.scala
+++ b/modules/e2e/src/test/scala/IntegrationSuite.scala
@@ -74,7 +74,8 @@ object IntegrationSuite extends IOSuite:
               topicId = "chess",
               troll = false,
               date = Instant.now().toEpochMilli(),
-              author = "nt9".some
+              author = "nt9".some,
+              category = "team-lichess"
             )
           )
           _ <- res.esClient.refreshIndex(Index.Forum)

--- a/modules/ingestor-core/src/main/smithy/model.smithy
+++ b/modules/ingestor-core/src/main/smithy/model.smithy
@@ -32,6 +32,9 @@ structure ForumSource {
   @required
   @jsonName("da")
   date: Long
+  @required
+  @jsonName("ca")
+  category: String
 }
 
 structure GameSource {


### PR DESCRIPTION
This PR extends forum search with support for filtering by forum category.
It prepares the ground for a follow-up PR in lila that will fix [lichess-org/lila#18240](https://github.com/lichess-org/lila/issues/18240)

The change is backward compatible and safe to deploy.
Note: Elasticsearch must be reindexed for the forum index to populate the new ca (category) field before category filtering will work.
Once reindexing is complete, the lila changes that pass categIds in search requests should be deployed.