### PR TITLE
Revert search query for owner and member

### DIFF
--- a/modules/elastic/src/main/scala/study.scala
+++ b/modules/elastic/src/main/scala/study.scala
@@ -23,15 +23,21 @@ case class Study(text: String, sorting: Option[Sorting], userId: Option[String])
 
   private def makeQuery() = {
     val parsed = QueryParser(text, List("owner", "member"))
+
     val matcher: Query =
       if parsed.terms.isEmpty then matchAllQuery()
       else
-        multiMatchQuery(parsed.terms.mkString(" "))
-          .field(Fields.name, 3.0)
-          .field(Fields.topics, 2.0)
-          .field(Fields.description, 1.0)
-          .analyzer("english_with_chess_synonyms")
-          .operator("and")
+        val text = parsed.terms.mkString(" ")
+        boolQuery().should(
+          multiMatchQuery(text)
+            .field(Fields.name, 3.0)
+            .field(Fields.topics, 2.0)
+            .field(Fields.description, 1.0)
+            .analyzer("english_with_chess_synonyms")
+            .operator("and"),
+          multiMatchQuery(text)
+            .fields(Fields.owner, Fields.members)
+        )
 
     boolQuery()
       .must:


### PR DESCRIPTION
It's used to be full text search for all searchable files which includes
owner and members, but now we used a more sophisticated analyzer with
some chess synonyms filter, which doesn't make sense to search with
owner and/or members. So I removed them from full text search. But it
seems people rely on that for manage their studies, most probably to
working with students.
