### PR TITLE
Use projections for white_user and black_user

### DIFF
--- a/modules/clickhouse/src/main/scala/lila/search/clickhouse/game/GameTable.scala
+++ b/modules/clickhouse/src/main/scala/lila/search/clickhouse/game/GameTable.scala
@@ -36,11 +36,12 @@ object GameTable:
       white_bot    Bool CODEC(ZSTD(1)),
       black_bot    Bool CODEC(ZSTD(1)),
 
-      INDEX idx_white white_user TYPE bloom_filter(0.01) GRANULARITY 1,
-      INDEX idx_black black_user TYPE bloom_filter(0.01) GRANULARITY 1
+      PROJECTION proj_white (SELECT * ORDER BY white_user, date, id),
+      PROJECTION proj_black (SELECT * ORDER BY black_user, date, id)
     ) ENGINE = ReplacingMergeTree()
     PARTITION BY toYYYYMM(date)
     ORDER BY (date, id)
+    SETTINGS deduplicate_merge_projection_mode = 'rebuild'
   """
 
   def create: ConnectionIO[Int] = Fragment.const(ddl).update.run


### PR DESCRIPTION
We have 10 billion documents, and Nearly every game search query filters
by user
(`user1`, `user2`, `winner`, `loser`, `whiteUser`, `blackUser`). The dominant
access pattern is: "Find games for a specific player, optionally filtered by
perf/rating/date/etc., sorted by date desc".

Estimation is for 10B games: the base table is around 60-80 GB and
each projection will be around that as well, so totally it takes around
240 Gb storage for the data. Which is still very good
