### PR TITLE
fix: include stalemates and insufficient-material claims in Draw searches

### DIFF
--- a/modules/e2e/src/test/scala/IntegrationSuite.scala
+++ b/modules/e2e/src/test/scala/IntegrationSuite.scala
@@ -301,6 +301,30 @@ object IntegrationSuite extends IOSuite:
     sorting = GameSorting("field", "asc")
   )
 
+  // A drawn game whose fields match the Draw search below but none of the other filters.
+  def drawGameSource(status: Int) = GameSource(
+    status = status,
+    turns = 100,
+    rated = true,
+    perf = 2,
+    winnerColor = 3,
+    date = Timestamp(2001, 10, 20, 12, 20, 20).toInstant.getEpochSecond,
+    analysed = false,
+    averageRating = 150,
+    ai = 0,
+    duration = 50,
+    clockInit = 50,
+    clockInc = 50,
+    whiteUser = "white",
+    blackUser = "black",
+    source = 0,
+    whiteRating = 150,
+    blackRating = 150,
+    chess960Pos = 1000,
+    whiteBot = false,
+    blackBot = false
+  )
+
   test("game"): res =>
     Clients
       .search(uri)
@@ -333,6 +357,9 @@ object IntegrationSuite extends IOSuite:
               blackBot = false
             )
           )
+          _ <- res.esClient.store(Index.Game, Id("draw_stalemate"), drawGameSource(32))
+          _ <- res.esClient.store(Index.Game, Id("draw_normal"), drawGameSource(34))
+          _ <- res.esClient.store(Index.Game, Id("draw_insufficient_material"), drawGameSource(39))
           _ <- res.esClient.refreshIndex(Index.Game)
           a <- service.search(defaultGame.copy(perf = List(1)), from, size)
           b <- service.search(defaultGame.copy(loser = "black".some), from, size)
@@ -345,4 +372,18 @@ object IntegrationSuite extends IOSuite:
             from,
             size
           )
-        yield expect(a.hitIds.size == 1 && b == a && c == a && d == a && e == a && f == a && g == a)
+          draw <- service.search(defaultGame.copy(status = 34.some), from, size)
+        yield expect.all(
+          a.hitIds.size == 1,
+          b == a,
+          c.hitIds.size == 4,
+          d == a,
+          e == a,
+          f == a,
+          g == a,
+          draw.hitIds.size == 3,
+          draw.hitIds.contains(Id("draw_stalemate")),
+          draw.hitIds.contains(Id("draw_normal")),
+          draw.hitIds.contains(Id("draw_insufficient_material")),
+          !draw.hitIds.contains(Id("game_id"))
+        )

--- a/modules/elastic/src/main/scala/game.scala
+++ b/modules/elastic/src/main/scala/game.scala
@@ -95,6 +95,15 @@ case class Game(
         case s: String => termQuery(name, s.toLowerCase)
         case x => termQuery(name, x)
 
+    // A "Draw" result groups every drawn outcome that carries its own game status
+    // id in scalachess: Stalemate, Draw, and InsufficientMaterialClaim. Selecting it
+    // must match all three, not only the literal Draw status.
+    // https://github.com/lichess-org/lila-search/issues/608
+    def statusQueries: List[Query] =
+      status.toList.map: s =>
+        if s == Game.drawStatusId then termsQuery(Fields.status, Game.drawStatusIds)
+        else termQuery(Fields.status, s)
+
     List(
       userQueries,
       winnerQueries,
@@ -111,7 +120,7 @@ case class Game(
       perf.nonEmpty.fold(List(termsQuery(Fields.perf, perf)), Nil),
       toQueries(source, Fields.source),
       toQueries(rated, Fields.rated),
-      toQueries(status, Fields.status),
+      statusQueries,
       toQueries(analysed, Fields.analysed),
       toQueries(whiteUser, Fields.whiteUser),
       toQueries(blackUser, Fields.blackUser)
@@ -144,6 +153,14 @@ object Mapping:
 
 object Game:
   val index = "game"
+
+  // Drawn outcomes have distinct scalachess `Status` ids: Stalemate (32),
+  // Draw (34 — agreement / 50-move / threefold / automatic insufficient material)
+  // and InsufficientMaterialClaim (39). A "Draw" result search groups all three.
+  // The ids are inlined rather than read from `chess.Status` because the elastic
+  // module does not depend on scalachess; the index stores raw `Status.id` values.
+  val drawStatusId = 34
+  val drawStatusIds = List(32, 34, 39)
 
 case class Sorting(f: String, order: String):
   import com.sksamuel.elastic4s.requests.searches.sort.SortOrder

--- a/modules/elastic/src/test/scala/GameQueryTest.scala
+++ b/modules/elastic/src/test/scala/GameQueryTest.scala
@@ -1,0 +1,17 @@
+package lila.search
+
+import lila.search.game.Game
+import weaver.*
+
+object GameQueryTest extends FunSuite:
+
+  private def queryString(game: Game): String =
+    game.searchDef(From(0), Size(10)).query.get.toString
+
+  test("Draw result also matches stalemates and insufficient material claims"):
+    val query = queryString(Game(status = Some(Game.drawStatusId)))
+    expect(query.contains("32") && query.contains("34") && query.contains("39"))
+
+  test("a non-Draw result matches its status exactly"):
+    val query = queryString(Game(status = Some(30))) // Mate
+    expect(query.contains("30") && !query.contains("32") && !query.contains("39"))


### PR DESCRIPTION
## What
  Advanced game search with **Result = Draw** now returns *all* drawn games,
  including those that ended in **Stalemate** and **Insufficient Material Claim** —
  not only games whose status is the literal `Draw`.

  ## Why
  A "Draw" result was filtered as `status == Status.Draw` (id 34). But three
  distinct no-winner outcomes each carry their own scalachess `Status` id:

  - `Stalemate` (32)
  - `Draw` (34) — agreement / 50-move / threefold / automatic insufficient material
  - `InsufficientMaterialClaim` (39) — draw claimed when the opponent flags with
    insufficient mating material

  Only `34` was matched, so stalemates and insufficient-material claims were
  silently excluded from Draw searches.

  ## Change
  `statusQueries` expands a `Draw` filter into a `terms` query over `{32, 34, 39}`.
  Every other status filter keeps its exact single-status match. The ids are
  inlined (with a comment) rather than read from `chess.Status`, because the
  `elastic` module has no scalachess dependency and the index stores raw
  `Status.id` values.

  ## How to verify
  - `sbt "elastic/testOnly lila.search.GameQueryTest"` — added regression test
    covers both the Draw-expands and non-Draw-stays-exact cases.
  - Manually: advanced search, Result = Draw, for a player with stalemate games —
    they now appear alongside other draws.

  This makes "Draw" an umbrella that overlaps the separate "Stalemate" and
  "Insufficient Material Claim" options in the Result dropdown, and means a `Draw`
  filter can no longer return *only* status-34 draws. That matches the request in
  the issue, but it's a behavior change to an existing option — happy to adjust if
  you'd prefer a different shape.

  Closes #608
