### PR TITLE
Bump dependencies

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "3.10.7"
+version = "3.11.1"
 runner.dialect = scala3
 
 align.preset = none

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import Dependencies.*
 import org.typelevel.scalacoptions.ScalacOptions
 
-scalaVersion := "3.8.3"
+scalaVersion := "3.8.4"
 versionScheme := Some("early-semver")
 organization := "org.lichess.search"
 run / fork := true
@@ -137,7 +137,7 @@ lazy val ingestorApp = project
       otel4sInstrumentationMetrics
     ),
     dockerSettings,
-    Compile / doc / sources := Seq.empty,
+    Compile / doc / sources := Seq.empty
   )
   .dependsOn(ingestorCore)
 
@@ -158,7 +158,7 @@ lazy val ingestorCli = project
       weaver
     ),
     dockerSettings,
-    Compile / doc / sources := Seq.empty,
+    Compile / doc / sources := Seq.empty
   )
   .dependsOn(elastic, core, ingestorCore)
 
@@ -239,7 +239,7 @@ lazy val app = project
       otel4sHttp4sMetrics
     ),
     dockerSettings,
-    Compile / doc / sources := Seq.empty,
+    Compile / doc / sources := Seq.empty
   )
   .dependsOn(api, elastic)
 

--- a/modules/lila-game-export/src/main/scala/GameCsv.scala
+++ b/modules/lila-game-export/src/main/scala/GameCsv.scala
@@ -5,6 +5,8 @@ import fs2.data.csv.*
 import fs2.data.csv.generic.semiauto.*
 import lila.search.ingestor.DbGame
 
+import scala.annotation.nowarn
+
 case class GameCsv(
     id: String,
     status: Int,
@@ -28,6 +30,7 @@ case class GameCsv(
 )
 
 object GameCsv:
+  @nowarn("msg=is not accessible here")
   given CsvRowEncoder[GameCsv, String] = deriveCsvRowEncoder
 
   def fromDbGame(game: DbGame): GameCsv =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,18 +8,18 @@ object Dependencies:
 
   object V:
     val catsEffect = "3.7.0"
-    val catsMtl = "1.6.0"
-    val ciris = "3.13.0"
+    val catsMtl = "1.7.0"
+    val ciris = "3.15.0"
     val chess = "17.15.5"
     val decline = "2.6.2"
     val elastic4s = "9.3.0"
     val fs2 = "3.13.0"
-    val fs2Data = "1.13.0"
+    val fs2Data = "1.14.0"
     val http4s = "0.23.34"
-    val mongo4cats = "0.7.17"
-    val otel4sCore = "0.16.0"
-    val otel4sSdk = "0.18.0"
-    val otel4sHttp4s = "0.17.0"
+    val mongo4cats = "0.7.18"
+    val otel4sCore = "1.0.0"
+    val otel4sSdk = "0.19.0"
+    val otel4sHttp4s = "0.18.0"
 
   def http4s(artifact: String) = "org.http4s" %% s"http4s-$artifact" % V.http4s
   def smithy4s(artifact: String) = "com.disneystreaming.smithy4s" %% s"smithy4s-$artifact" % smithy4sVersion
@@ -50,7 +50,7 @@ object Dependencies:
   val jsoniterCore = "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % "2.37.10"
   val jsoniterMacro = "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.37.10"
 
-  val playWS = "com.typesafe.play" %% "play-ahc-ws-standalone" % "2.2.15"
+  val playWS = "com.typesafe.play" %% "play-ahc-ws-standalone" % "2.2.16"
 
   val elastic4sHttp4sClient = "nl.gn0s1s" %% "elastic4s-client-http4s" % V.elastic4s
 
@@ -59,8 +59,8 @@ object Dependencies:
   val circe = "io.circe" %% "circe-core" % "0.14.15"
 
   val log4Cats = "org.typelevel" %% "log4cats-slf4j" % "2.8.0"
-  val logback = "ch.qos.logback" % "logback-classic" % "1.5.32"
-  val ducktape = "io.github.arainko" %% "ducktape" % "0.2.12"
+  val logback = "ch.qos.logback" % "logback-classic" % "1.5.34"
+  val ducktape = "io.github.arainko" %% "ducktape" % "0.2.13"
 
   val otel4sCore = "org.typelevel" %% "otel4s-core" % V.otel4sCore
   val otel4sInstrumentationMetrics = "org.typelevel" %% "otel4s-instrumentation-metrics" % V.otel4sCore
@@ -75,8 +75,8 @@ object Dependencies:
   val declineCatsEffect = "com.monovore" %% "decline-effect" % V.decline
 
   val testContainers = "com.dimafeng" %% "testcontainers-scala-core" % "0.44.1" % Test
-  val weaver = "org.typelevel" %% "weaver-cats" % "0.12.0" % Test
-  val weaverScalaCheck = "org.typelevel" %% "weaver-scalacheck" % "0.12.0" % Test
+  val weaver = "org.typelevel" %% "weaver-cats" % "0.13.0" % Test
+  val weaverScalaCheck = "org.typelevel" %% "weaver-scalacheck" % "0.13.0" % Test
   val catsEffectTestKit = "org.typelevel" %% "cats-effect-testkit" % V.catsEffect % Test
   val scalacheck = "org.scalacheck" %% "scalacheck" % "1.17.0" % Test
   val snapshot4s = "com.siriusxm" %% "snapshot4s-weaver" % snapshot4sVersion % Test

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=2.0.0-RC12
+sbt.version=2.0.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,9 +3,9 @@ excludeDependencies ++= Seq(
   ExclusionRule("org.scala-lang.modules", "scala-xml_2.13")
 )
 
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.6")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.7")
 
-addSbtPlugin("com.disneystreaming.smithy4s" % "smithy4s-sbt-codegen" % "0.19.4")
+addSbtPlugin("com.disneystreaming.smithy4s" % "smithy4s-sbt-codegen" % "0.19.7")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.13.1")
 
@@ -17,9 +17,8 @@ addSbtPlugin("com.github.sbt" % "sbt-release" % "1.5.0")
 
 addSbtPlugin("org.polyvariant" % "smithy-scala-tools-sbt" % "0.3.1")
 
-addSbtPlugin("com.siriusxm" % "sbt-snapshot4s" % "0.2.9")
+addSbtPlugin("com.siriusxm" % "sbt-snapshot4s" % "0.2.10")
 
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.6")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.1")
 
-addSbtPlugin("org.typelevel" % "sbt-tpolecat" % "0.5.4")
-
+addSbtPlugin("org.typelevel" % "sbt-tpolecat" % "0.5.6")


### PR DESCRIPTION
Build/plugins:
- sbt 2.0.0-RC12 -> 2.0.0
- scala3-library 3.8.3 -> 3.8.4
- sbt-scalafix 0.14.6 -> 0.14.7
- smithy4s 0.19.4 -> 0.19.7
- sbt-snapshot4s / snapshot4s-weaver 0.2.9 -> 0.2.10
- sbt-scalafmt 2.5.6 -> 2.6.1
- scalafmt-core 3.10.7 -> 3.11.1
- sbt-tpolecat 0.5.4 -> 0.5.6

Libraries:
- cats-mtl 1.6.0 -> 1.7.0
- ciris / ciris-http4s 3.13.0 -> 3.15.0
- fs2-data-csv(-generic) 1.13.0 -> 1.14.0
- mongo4cats-core / -circe 0.7.17 -> 0.7.18
- otel4s-core 0.16.0 -> 1.0.0
- otel4s-sdk 0.18.0 -> 0.19.0
- http4s-otel4s-middleware 0.17.0 -> 0.18.0
- play-ahc-ws-standalone 2.2.15 -> 2.2.16
- logback-classic 1.5.32 -> 1.5.34
- ducktape 0.2.12 -> 0.2.13
- weaver-cats / weaver-scalacheck 0.12.0 -> 0.13.0 (required by snapshot4s 0.2.10)